### PR TITLE
클라우드플레어 사용 시 오류 안내

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This repository provides you what you have to prepare to play **KKuTu**.
 - Once the server is successfully installed, you can do just the last step of above-mentioned guideline whenever you want to run the server.
 - You can open a browser and go to `127.0.0.1`(or external IP address for other people) to play **KKuTu**.
 - Ranking and some session features require [Redis](https://redis.io/) server. This is optional.
+- If you use Cloudflare, you should set status of DNS Tab to 'DNS only'. 'DNS and HTTP proxy (CDN)' status is the reason of unable to open and enter the room.
 
 #### License
 - [GNU General Public License](https://github.com/JJoriping/KKuTu/blob/master/LICENSE)
@@ -92,6 +93,7 @@ This repository provides you what you have to prepare to play **KKuTu**.
 - 서버가 정상적으로 설치된 다음부터는 서버를 실행시키기 위해서 가장 마지막 단계만 수행하면 됩니다.
 - 서버가 성공적으로 열린 후 웹 브라우저에서 `127.0.0.1`(다른 사람들은 해당 컴퓨터의 외부 IP 주소)로 접속하여 끄투를 즐길 수 있습니다.
 - 랭킹 및 세션 기능 일부는 [Redis](https://redis.io/) 서버가 실행되어야만 작동합니다. 일단 이를 설치하지 않아도 서버가 작동할 수 있도록 조치했습니다.
+- 클라우드 플레어를 사용하신다면, DNS 탭의 status를 DNS only로 두세요. DNS and HTTP proxy (CDN)으로 둘 경우, 방 만들기와 방 입장이 되지 않습니다.
 
 #### 라이선스
 - [GNU 일반 공중 사용 라이선스](https://github.com/JJoriping/KKuTu/blob/master/LICENSE)


### PR DESCRIPTION
클라우드플레어를 사용할 때, 클라우드플레어 서버를 거쳐가게 설정하면 방 만들기와 방 입장이 안된다는 것을 안내합니다.